### PR TITLE
Handle headers four through six in process_block

### DIFF
--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -64,7 +64,10 @@ defmodule Draft.Block do
         %{
           "one" => "h1",
           "two" => "h2",
-          "three" => "h3"
+          "three" => "h3",
+          "four" => "h4",
+          "five" => "h5",
+          "six" => "h6"
         }
       end
     end

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -82,6 +82,66 @@ defmodule DraftTest do
     assert to_html(input) == output
   end
 
+  test "generate a <h4>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-four",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h4>Hello</h4>"
+    assert to_html(input) == output
+  end
+
+  test "generate a <h5>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-five",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h5>Hello</h5>"
+    assert to_html(input) == output
+  end
+
+  test "generate a <h6>" do
+    input = %{
+      "entityMap" => %{},
+      "blocks" => [
+        %{
+          "key" => "9d21d",
+          "text" => "Hello",
+          "type" => "header-six",
+          "depth" => 0,
+          "inlineStyleRanges" => [],
+          "entityRanges" => [],
+          "data" => %{}
+        }
+      ]
+    }
+
+    output = "<h6>Hello</h6>"
+    assert to_html(input) == output
+  end
+
   test "generate a <blockquote>" do
     input = %{
       "entityMap" => %{},


### PR DESCRIPTION
We now need to be able to handle all header tags not just h1, h2, and h3