### PR TITLE
Fixes UL and OL in outlook for

### DIFF
--- a/lib/draft/block.ex
+++ b/lib/draft/block.ex
@@ -49,7 +49,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<li>#{apply_ranges(block, entity_map, context)}</li>"
+        "<li style=\"mso-special-format:numbullet;\">#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def process_block(
@@ -57,7 +57,7 @@ defmodule Draft.Block do
             entity_map,
             context
           ) do
-        "<li>#{apply_ranges(block, entity_map, context)}</li>"
+        "<li style=\"mso-special-format:bullet;\">#{apply_ranges(block, entity_map, context)}</li>"
       end
 
       def header_tags do

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -57,7 +57,6 @@ defmodule DraftTree do
           key: key,
           styles: styles,
           offset: offset,
-          length: length,
           text: text
         },
         processor


### PR DESCRIPTION
unfortunately the suggestions in https://litmus.com/blog/the-ultimate-guide-to-bulleted-lists-in-html-email did not work.

This worked:  https://litmus.com/community/discussions/752-can-we-use-ul-and-li-in-email
Source for numbullet: https://forum.aspose.com/t/paragraphs-exporttohtml-with-bullet-number-list/194592/2