### PR TITLE
fix: correct codepoint slicing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+/tmp

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -4,7 +4,7 @@ defmodule DraftTree do
   end
 
   def build_tree(ranges, text) do
-    root_node = %Node{text: text, length: String.length(text), styles: nil}
+    root_node = %Node{text: text, length: utf16_length(text), styles: nil}
 
     Enum.reduce(ranges, root_node, fn range, tree -> insert_node(tree, range, text) end)
   end
@@ -28,7 +28,7 @@ defmodule DraftTree do
                 offset: range["offset"],
                 styles: range["styles"],
                 key: range["key"],
-                text: slice_as_codepoints(text, range["offset"], range["length"])
+                text: slice_as_utf16(text, range["offset"], range["length"])
               }
             ]
         )
@@ -64,30 +64,35 @@ defmodule DraftTree do
     Enum.map(children, fn child -> {child, process_tree(child, processor)} end)
     |> Enum.reverse()
     |> Enum.reduce(text, fn {child, child_text}, acc ->
-      {start, rest} = split_at_as_codepoints(acc, child.offset - offset)
+      {start, rest} = split_at_as_utf16(acc, child.offset - offset)
 
       {_, finish} =
-        split_at_as_codepoints(rest, child.offset - offset + child.length - String.length(start))
+        split_at_as_utf16(rest, child.offset - offset + child.length - utf16_length(start))
 
       start <> child_text <> finish
     end)
     |> processor.(styles, key)
   end
 
-  defp slice_as_codepoints(string, offset, length) do
-    string
-    |> String.codepoints()
-    |> Enum.slice(offset, length)
-    |> List.to_string()
+  # Draft.js reports `offset` and `length` in UTF-16 code units (the JavaScript
+  # string indexing scheme). Elixir strings are UTF-8, and both String.slice/3
+  # (graphemes) and codepoint-based slicing miscount any character outside the
+  # Basic Multilingual Plane — e.g. most emoji (🔴 U+1F534, 🎶 U+1F3B6), which
+  # are a single codepoint but two UTF-16 code units (a surrogate pair). To match
+  # Draft's offsets we convert to UTF-16, slice on 2-byte code-unit boundaries,
+  # then convert back.
+  defp utf16_length(string), do: byte_size(to_utf16(string)) |> div(2)
+
+  defp slice_as_utf16(string, offset, length) do
+    <<_::binary-size(offset * 2), slice::binary-size(length * 2), _::binary>> = to_utf16(string)
+    from_utf16(slice)
   end
 
-  defp split_at_as_codepoints(string, offset) do
-    {start, finish} =
-      string
-      |> String.codepoints()
-      |> Enum.split(offset)
-      |> then(fn {start, finish} -> {List.to_string(start), List.to_string(finish)} end)
-
-    {start, finish}
+  defp split_at_as_utf16(string, offset) do
+    <<start::binary-size(offset * 2), finish::binary>> = to_utf16(string)
+    {from_utf16(start), from_utf16(finish)}
   end
+
+  defp to_utf16(string), do: :unicode.characters_to_binary(string, :utf8, {:utf16, :big})
+  defp from_utf16(binary), do: :unicode.characters_to_binary(binary, {:utf16, :big}, :utf8)
 end

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -4,7 +4,11 @@ defmodule DraftTree do
   end
 
   def build_tree(ranges, text) do
-    root_node = %Node{text: text, length: utf16_length(text), styles: nil}
+    root_node = %Node{
+      text: text,
+      length: text |> String.codepoints() |> Enum.count(),
+      styles: nil
+    }
 
     Enum.reduce(ranges, root_node, fn range, tree -> insert_node(tree, range, text) end)
   end
@@ -28,7 +32,7 @@ defmodule DraftTree do
                 offset: range["offset"],
                 styles: range["styles"],
                 key: range["key"],
-                text: slice_as_utf16(text, range["offset"], range["length"])
+                text: slice_as_codepoints(text, range["offset"], range["length"])
               }
             ]
         )
@@ -64,54 +68,25 @@ defmodule DraftTree do
     Enum.map(children, fn child -> {child, process_tree(child, processor)} end)
     |> Enum.reverse()
     |> Enum.reduce(text, fn {child, child_text}, acc ->
-      {start, rest} = split_at_as_utf16(acc, child.offset - offset)
+      {start, rest} = split_at_as_codepoints(acc, child.offset - offset)
 
-      {_, finish} = split_at_as_utf16(rest, child.length)
+      {_, finish} = split_at_as_codepoints(rest, child.length)
 
       start <> child_text <> finish
     end)
     |> processor.(styles, key)
   end
 
-  # Draft.js reports `offset` and `length` in UTF-16 code units (the JavaScript
-  # string indexing scheme). Elixir strings are UTF-8, and both String.slice/3
-  # (graphemes) and codepoint-based slicing miscount any character outside the
-  # Basic Multilingual Plane, e.g. most emoji (🔴 U+1F534, 🎶 U+1F3B6), which are
-  # a single codepoint but two UTF-16 code units (a surrogate pair).
-  #
-  # So we convert to UTF-16 and let Elixir's binary syntax index by code unit:
-  # `size(n)-unit(16)` matches n segments of 16 bits, i.e. n UTF-16 code units.
-  defp utf16_length(string), do: div(bit_size(to_utf16(string)), 16)
-
-  defp slice_as_utf16(string, offset, length) do
-    utf16_bin = to_utf16(string)
-
-    try do
-      <<_::size(offset)-unit(16), slice::size(length)-unit(16)-binary, _::binary>> = utf16_bin
-      from_utf16(slice)
-    rescue
-      MatchError -> ""
-    end
+  defp slice_as_codepoints(string, offset, length) do
+    string
+    |> String.codepoints()
+    |> Enum.drop(offset)
+    |> Enum.take(length)
+    |> Enum.join()
   end
 
-  defp split_at_as_utf16(string, offset) do
-    utf16_bin = to_utf16(string)
-
-    try do
-      <<start::size(offset)-unit(16)-binary, finish::binary>> = utf16_bin
-      {from_utf16(start), from_utf16(finish)}
-    rescue
-      MatchError -> {"", ""}
-    end
-  end
-
-  defp to_utf16(string), do: :unicode.characters_to_binary(string, :utf8, {:utf16, :big})
-
-  defp from_utf16(binary) do
-    case :unicode.characters_to_binary(binary, {:utf16, :big}, :utf8) do
-      {:incomplete, acc, _rest} -> acc
-      {:error, encoded, _rest} -> encoded
-      result when is_binary(result) -> result
-    end
+  defp split_at_as_codepoints(string, offset) do
+    {start, rest} = string |> String.codepoints() |> Enum.split(offset)
+    {Enum.join(start), Enum.join(rest)}
   end
 end

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -97,5 +97,12 @@ defmodule DraftTree do
   end
 
   defp to_utf16(string), do: :unicode.characters_to_binary(string, :utf8, {:utf16, :big})
-  defp from_utf16(binary), do: :unicode.characters_to_binary(binary, {:utf16, :big}, :utf8)
+
+  defp from_utf16(binary) do
+    case :unicode.characters_to_binary(binary, {:utf16, :big}, :utf8) do
+      {:incomplete, _acc, _rest} -> ""
+      {:error, _encoded, _rest} -> ""
+      result when is_binary(result) -> result
+    end
+  end
 end

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -66,8 +66,7 @@ defmodule DraftTree do
     |> Enum.reduce(text, fn {child, child_text}, acc ->
       {start, rest} = split_at_as_utf16(acc, child.offset - offset)
 
-      {_, finish} =
-        split_at_as_utf16(rest, child.offset - offset + child.length - utf16_length(start))
+      {_, finish} = split_at_as_utf16(rest, child.length)
 
       start <> child_text <> finish
     end)
@@ -85,23 +84,33 @@ defmodule DraftTree do
   defp utf16_length(string), do: div(bit_size(to_utf16(string)), 16)
 
   defp slice_as_utf16(string, offset, length) do
-    <<_::size(offset)-unit(16), slice::size(length)-unit(16)-binary, _::binary>> =
-      to_utf16(string)
+    utf16_bin = to_utf16(string)
 
-    from_utf16(slice)
+    try do
+      <<_::size(offset)-unit(16), slice::size(length)-unit(16)-binary, _::binary>> = utf16_bin
+      from_utf16(slice)
+    rescue
+      MatchError -> ""
+    end
   end
 
   defp split_at_as_utf16(string, offset) do
-    <<start::size(offset)-unit(16)-binary, finish::binary>> = to_utf16(string)
-    {from_utf16(start), from_utf16(finish)}
+    utf16_bin = to_utf16(string)
+
+    try do
+      <<start::size(offset)-unit(16)-binary, finish::binary>> = utf16_bin
+      {from_utf16(start), from_utf16(finish)}
+    rescue
+      MatchError -> {"", ""}
+    end
   end
 
   defp to_utf16(string), do: :unicode.characters_to_binary(string, :utf8, {:utf16, :big})
 
   defp from_utf16(binary) do
     case :unicode.characters_to_binary(binary, {:utf16, :big}, :utf8) do
-      {:incomplete, _acc, _rest} -> ""
-      {:error, _encoded, _rest} -> ""
+      {:incomplete, acc, _rest} -> acc
+      {:error, encoded, _rest} -> encoded
       result when is_binary(result) -> result
     end
   end

--- a/lib/draft/tree.ex
+++ b/lib/draft/tree.ex
@@ -77,19 +77,22 @@ defmodule DraftTree do
   # Draft.js reports `offset` and `length` in UTF-16 code units (the JavaScript
   # string indexing scheme). Elixir strings are UTF-8, and both String.slice/3
   # (graphemes) and codepoint-based slicing miscount any character outside the
-  # Basic Multilingual Plane — e.g. most emoji (🔴 U+1F534, 🎶 U+1F3B6), which
-  # are a single codepoint but two UTF-16 code units (a surrogate pair). To match
-  # Draft's offsets we convert to UTF-16, slice on 2-byte code-unit boundaries,
-  # then convert back.
-  defp utf16_length(string), do: byte_size(to_utf16(string)) |> div(2)
+  # Basic Multilingual Plane, e.g. most emoji (🔴 U+1F534, 🎶 U+1F3B6), which are
+  # a single codepoint but two UTF-16 code units (a surrogate pair).
+  #
+  # So we convert to UTF-16 and let Elixir's binary syntax index by code unit:
+  # `size(n)-unit(16)` matches n segments of 16 bits, i.e. n UTF-16 code units.
+  defp utf16_length(string), do: div(bit_size(to_utf16(string)), 16)
 
   defp slice_as_utf16(string, offset, length) do
-    <<_::binary-size(offset * 2), slice::binary-size(length * 2), _::binary>> = to_utf16(string)
+    <<_::size(offset)-unit(16), slice::size(length)-unit(16)-binary, _::binary>> =
+      to_utf16(string)
+
     from_utf16(slice)
   end
 
   defp split_at_as_utf16(string, offset) do
-    <<start::binary-size(offset * 2), finish::binary>> = to_utf16(string)
+    <<start::size(offset)-unit(16)-binary, finish::binary>> = to_utf16(string)
     {from_utf16(start), from_utf16(finish)}
   end
 

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -332,6 +332,35 @@ defmodule DraftTest do
     assert to_html(input) == output
   end
 
+  test "handles offsets correctly with supplementary-plane emoji (surrogate pairs)" do
+    # 🔴 (U+1F534) is a single codepoint but TWO UTF-16 code units, so Draft.js
+    # reports the link starting at offset 2. Codepoint-based slicing would be off
+    # by one here and wrap "oo" / leak into the next tag.
+    input = %{
+      "blocks" => [
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [%{"key" => 0, "length" => 3, "offset" => 2}],
+          "inlineStyleRanges" => [],
+          "key" => "df1r3",
+          "text" => "🔴Foo",
+          "type" => "unstyled"
+        }
+      ],
+      "entityMap" => %{
+        "0" => %{
+          "data" => %{"target" => "_blank", "url" => "https://google.com"},
+          "mutability" => "MUTABLE",
+          "type" => "LINK"
+        }
+      }
+    }
+
+    output = "<p>🔴<a href=\"https://google.com\">Foo</a></p>"
+    assert to_html(input) == output
+  end
+
   test "wraps overlapping entities and inline styles" do
     input = %{
       "entityMap" => %{

--- a/test/draft_test.exs
+++ b/test/draft_test.exs
@@ -333,15 +333,12 @@ defmodule DraftTest do
   end
 
   test "handles offsets correctly with supplementary-plane emoji (surrogate pairs)" do
-    # 🔴 (U+1F534) is a single codepoint but TWO UTF-16 code units, so Draft.js
-    # reports the link starting at offset 2. Codepoint-based slicing would be off
-    # by one here and wrap "oo" / leak into the next tag.
     input = %{
       "blocks" => [
         %{
           "data" => %{},
           "depth" => 0,
-          "entityRanges" => [%{"key" => 0, "length" => 3, "offset" => 2}],
+          "entityRanges" => [%{"key" => 0, "length" => 3, "offset" => 1}],
           "inlineStyleRanges" => [],
           "key" => "df1r3",
           "text" => "🔴Foo",

--- a/test/special_character_edge_cases_test.exs
+++ b/test/special_character_edge_cases_test.exs
@@ -132,8 +132,8 @@ defmodule SpecialCharacterEdgeCasesTest do
     end
   end
 
-  describe "KNOWN ISSUE: Invalid UTF-16 offsets (half surrogate pairs)" do
-    test "half surrogate offset is handled gracefully (no crash)" do
+  describe "KNOWN ISSUE: Invalid UTF-16 lengths (half surrogate pairs)" do
+    test "half surrogate length is handled gracefully (no crash)" do
       input = %{
         "entityMap" => %{},
         "blocks" => [
@@ -149,9 +149,9 @@ defmodule SpecialCharacterEdgeCasesTest do
         ]
       }
 
-      # Invalid UTF-16 offset (lands in middle of surrogate pair) is now handled gracefully
-      # The code no longer crashes with Protocol.UndefinedError
-      # Note: Text reconstruction may be incomplete with invalid offsets, but at least it doesn't crash
+      # Invalid UTF-16 length (slicing only half of a surrogate pair - the emoji is 2 UTF-16 code units)
+      # The code now handles this gracefully without crashing
+      # Text reconstruction may be incomplete with invalid lengths, but at least it doesn't crash
       output = to_html(input)
       assert is_binary(output)
       assert String.starts_with?(output, "<p>")

--- a/test/special_character_edge_cases_test.exs
+++ b/test/special_character_edge_cases_test.exs
@@ -1,0 +1,161 @@
+defmodule SpecialCharacterEdgeCasesTest do
+  use ExUnit.Case
+  use Draft
+
+  describe "emoji handling" do
+    test "single emoji with style" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "test 🔴 end",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 5, "length" => 2}],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output == "<p>test <span style=\"font-weight: bold;\">🔴</span> end</p>"
+    end
+
+    test "emoji at start of text" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "🔴 red",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [%{"style" => "ITALIC", "offset" => 0, "length" => 2}],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output == "<p><span style=\"font-style: italic;\">🔴</span> red</p>"
+    end
+
+    test "multiple consecutive emojis" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "🔴🎶🔴",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 0, "length" => 6}],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output == "<p><span style=\"font-weight: bold;\">🔴🎶🔴</span></p>"
+    end
+
+    test "overlapping styles around emoji" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "test 🎶 end",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [
+              %{"style" => "BOLD", "offset" => 4, "length" => 4},
+              %{"style" => "ITALIC", "offset" => 5, "length" => 2}
+            ],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output ==
+               "<p>test<span style=\"font-weight: bold;\"> </span><span style=\"font-weight: bold; font-style: italic;\">🎶</span><span style=\"font-weight: bold;\"> </span>end</p>"
+    end
+  end
+
+  describe "combining marks and diacritics" do
+    test "accented characters" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "café",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 0, "length" => 4}],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output == "<p><span style=\"font-weight: bold;\">café</span></p>"
+    end
+  end
+
+  describe "edge cases" do
+    test "empty text block" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      output = to_html(input)
+      assert output == "<br>"
+    end
+  end
+
+  describe "KNOWN ISSUE: Invalid UTF-16 offsets (half surrogate pairs)" do
+    test "half surrogate offset is handled gracefully (no crash)" do
+      input = %{
+        "entityMap" => %{},
+        "blocks" => [
+          %{
+            "text" => "test 🔴 end",
+            "type" => "unstyled",
+            "depth" => 0,
+            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 5, "length" => 1}],
+            "entityRanges" => [],
+            "data" => %{},
+            "key" => "test"
+          }
+        ]
+      }
+
+      # Invalid UTF-16 offset (lands in middle of surrogate pair) is now handled gracefully
+      # The code no longer crashes with Protocol.UndefinedError
+      # Note: Text reconstruction may be incomplete with invalid offsets, but at least it doesn't crash
+      output = to_html(input)
+      assert is_binary(output)
+      assert String.starts_with?(output, "<p>")
+      assert String.ends_with?(output, "</p>")
+    end
+  end
+end

--- a/test/special_character_edge_cases_test.exs
+++ b/test/special_character_edge_cases_test.exs
@@ -11,7 +11,7 @@ defmodule SpecialCharacterEdgeCasesTest do
             "text" => "test 🔴 end",
             "type" => "unstyled",
             "depth" => 0,
-            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 5, "length" => 2}],
+            "inlineStyleRanges" => [%{"style" => "BOLD", "offset" => 5, "length" => 1}],
             "entityRanges" => [],
             "data" => %{},
             "key" => "test"
@@ -31,7 +31,7 @@ defmodule SpecialCharacterEdgeCasesTest do
             "text" => "🔴 red",
             "type" => "unstyled",
             "depth" => 0,
-            "inlineStyleRanges" => [%{"style" => "ITALIC", "offset" => 0, "length" => 2}],
+            "inlineStyleRanges" => [%{"style" => "ITALIC", "offset" => 0, "length" => 1}],
             "entityRanges" => [],
             "data" => %{},
             "key" => "test"
@@ -72,8 +72,8 @@ defmodule SpecialCharacterEdgeCasesTest do
             "type" => "unstyled",
             "depth" => 0,
             "inlineStyleRanges" => [
-              %{"style" => "BOLD", "offset" => 4, "length" => 4},
-              %{"style" => "ITALIC", "offset" => 5, "length" => 2}
+              %{"style" => "BOLD", "offset" => 4, "length" => 3},
+              %{"style" => "ITALIC", "offset" => 5, "length" => 1}
             ],
             "entityRanges" => [],
             "data" => %{},
@@ -83,8 +83,82 @@ defmodule SpecialCharacterEdgeCasesTest do
       }
 
       output = to_html(input)
+
       assert output ==
                "<p>test<span style=\"font-weight: bold;\"> </span><span style=\"font-weight: bold; font-style: italic;\">🎶</span><span style=\"font-weight: bold;\"> </span>end</p>"
+    end
+
+    test "bold alignment bug" do
+      inputs = [
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 25, "style" => "BOLD"}],
+          "key" => "d9dul",
+          "text" => "❤️ should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 24, "style" => "BOLD"}],
+          "key" => "5vbhk",
+          "text" => "🔴 should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 25, "style" => "BOLD"}],
+          "key" => "dub33",
+          "text" => "♥️ should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 25, "style" => "BOLD"}],
+          "key" => "4g62t",
+          "text" => "👍🏻 should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 24, "style" => "BOLD"}],
+          "key" => "2shv8",
+          "text" => "👍 should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 24, "style" => "BOLD"}],
+          "key" => "gi79",
+          "text" => "🐛 should not effect the bold here",
+          "type" => "unstyled"
+        },
+        %{
+          "data" => %{},
+          "depth" => 0,
+          "entityRanges" => [],
+          "inlineStyleRanges" => [%{"length" => 4, "offset" => 30, "style" => "BOLD"}],
+          "key" => "3tbdr",
+          "text" => "🧑\u200D🧑\u200D🧒\u200D🧒 should not effect the bold here",
+          "type" => "unstyled"
+        }
+      ]
+
+      Enum.each(inputs, fn i ->
+        output = to_html(%{"entityMap" => %{}, "blocks" => [i]})
+        assert String.match?(output, ~r{<span[^>]+>bold</span>})
+      end)
     end
   end
 
@@ -132,8 +206,8 @@ defmodule SpecialCharacterEdgeCasesTest do
     end
   end
 
-  describe "KNOWN ISSUE: Invalid UTF-16 lengths (half surrogate pairs)" do
-    test "half surrogate length is handled gracefully (no crash)" do
+  describe "KNOWN ISSUE: codepoint slicing was inaccurate for some emojis" do
+    test "codepoint slicing is correct" do
       input = %{
         "entityMap" => %{},
         "blocks" => [
@@ -149,9 +223,6 @@ defmodule SpecialCharacterEdgeCasesTest do
         ]
       }
 
-      # Invalid UTF-16 length (slicing only half of a surrogate pair - the emoji is 2 UTF-16 code units)
-      # The code now handles this gracefully without crashing
-      # Text reconstruction may be incomplete with invalid lengths, but at least it doesn't crash
       output = to_html(input)
       assert is_binary(output)
       assert String.starts_with?(output, "<p>")


### PR DESCRIPTION
SC-7860

Right now, we are having issues with certain emojis that have different offsets. This PR takes a swing at addressing these

<img src="https://static.klipy.com/ii/925f17378dd1893b674a723c07535afe/c3/17/1HTbsQYA.gif"/>